### PR TITLE
feat(firebase): getNoticeList 함수 반환 순서 설정

### DIFF
--- a/src/shared/firebase/noticeService.ts
+++ b/src/shared/firebase/noticeService.ts
@@ -6,6 +6,8 @@ import {
   getDoc,
   deleteDoc,
   doc,
+  query,
+  orderBy,
 } from "firebase/firestore/lite";
 import { Notice, NoticeDto } from "../types/notice";
 import { db } from "./firebaseConfig";
@@ -31,7 +33,12 @@ export async function createNotice(newNotice: Notice): Promise<string> {
  */
 export async function getNoticeList(): Promise<NoticeDto[]> {
   try {
-    const querySnapshot = await getDocs(collection(db, "notice").withConverter(noticeConverter));
+    const q = query(
+      collection(db, "notice").withConverter(noticeConverter),
+      orderBy("order", "asc"),
+      orderBy("createdAt", "desc"),
+    );
+    const querySnapshot = await getDocs(q);
     const result: NoticeDto[] = [];
     querySnapshot.forEach((doc) => {
       result.push({ id: doc.id, ...doc.data() });


### PR DESCRIPTION
## 관련 Issue

- closes #29 

## PR 설명

firebase의 getNoticeList 함수에서 noticeDto 리스트를 반환할 때 정렬하도록 하였습니다.
order가 작을수록, order가 같다면 createdAt 타임스탬프가 최근에 생성된 것일수록 먼저 반환됩니다.

## 기타사항

여러 필드에 대한 정렬을 구현하기 위해 복합 인덱스가 필요하여 파이어베이스 계정에서 인덱스를 추가하였습니다.