### PR TITLE
이미지 최대 높이를 1080으로 제한

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
           format: "webp",
           quality: "80", // 품질을 80%로 설정하여 손실 압축 적용
           removeMetadata: "",
+          h: "1080",
         }),
     }),
   ],


### PR DESCRIPTION
빌드시 이미지의 최대 높이를 제한하여 불필요한 트래픽을 방지합니다.