### PR TITLE
feat: 헤더 사용성 개선

### DIFF
--- a/src/components/Header/.css.ts
+++ b/src/components/Header/.css.ts
@@ -50,6 +50,7 @@ export const toggleBtnStyles = style({
   cursor: "pointer",
   display: "block",
   height: "1.5em",
+  width: "1.5em",
   "@media": {
     [`(min-width: ${mobileBreakpoint})`]: {
       display: "none",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -109,6 +109,7 @@ const Header: React.FC = () => {
                   className={`${menuItemLinkStyles} ${
                     isCurrentPath(item, location) ? highlightStyles : ""
                   }`}
+                  onClick={handleToggle}
                 >
                   {item.korean}
                 </Link>


### PR DESCRIPTION
- 페이지가 변경될 때마다 nav 항목이 닫히게 했습니다.
- 메뉴 버튼의 width를 구체적으로 명시했습니다.