### PR TITLE
chore: 타임테이블 아티스트이름 글자크기 축소

### DIFF
--- a/src/pages/Timetable/.css.ts
+++ b/src/pages/Timetable/.css.ts
@@ -154,11 +154,11 @@ export const artistImage = style({
 });
 
 export const artistName = style({
-  fontSize: "2rem",
+  fontSize: "1.7rem",
   fontFamily: vars.font.pyeongChangLight,
   "@media": {
     "screen and (max-width: 768px)": {
-      fontSize: "2rem",
+      fontSize: "1.7rem",
     },
   },
 });


### PR DESCRIPTION
## PR 설명

<img width="294" alt="image" src="https://github.com/user-attachments/assets/f4036bd0-ef18-46da-85d5-7c7357fac5fc">

특정 화면 비율에서 다음과 같이 60주년 기념관 글자가 개행되어 보여서 글자 크기를 조금 줄였습니다.