### PR TITLE
fix: 스크롤 저장 위치 변경(sessionStorage)

### DIFF
--- a/src/components/Layout/scrollContol.tsx
+++ b/src/components/Layout/scrollContol.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from "react";
 import { useCurrentPage } from "../../shared/routing/routerUtils.ts";
 
-let savedScrollY = 0;
+const savedScrollYKey = "savedScrollY";
 
 const handleScroll = () => {
-  savedScrollY = window.scrollY;
-  console.log(window.scrollY);
+  sessionStorage.setItem(savedScrollYKey, String(window.scrollY));
 };
 
 export default function ScrollToTop({ children }: { children: React.ReactNode }) {
@@ -14,7 +13,10 @@ export default function ScrollToTop({ children }: { children: React.ReactNode })
   useEffect(() => {
     if (currentPage.scrollOptions === "never") return;
     if (currentPage.scrollOptions === "save") {
-      window.scrollTo(0, savedScrollY);
+      setTimeout(
+        () => window.scrollTo(0, Number(sessionStorage.getItem(savedScrollYKey)) || 0),
+        500,
+      );
     } else {
       window.scrollTo(0, 0);
     }


### PR DESCRIPTION
부스 내에서 상세 페이지로 이동한 후 사진을 보거나 새로고침을 하면 스크롤이 초기화 되는 문제가 있어 수정했습니다.

사실 잘 일어나지 않는 오류여서 꼭 패치하지 않아도 괜찮고,
setTimeout을 사용하는 등 문제가 있을 법한 코드라
충분히 고려해서 피드백해주시면 감사하겠습니다.
